### PR TITLE
Namespace all types by their API version

### DIFF
--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,53 +1,44 @@
-/**
- * Main `WebAudioModule` interface,
- * its constructor should be the `export default` of the ESM of each WAM.
- *
- * @template Node type of the `audioNode` property, could be any `AudioNode` that implements `WamNode`
- */
-export interface WebAudioModule<Node extends WamNode = WamNode> {
-    /** should return `true` */
-    readonly isWebAudioModule: boolean;
-    /** The `AudioContext` where the plugin's node lives in */
-    audioContext: BaseAudioContext;
-    /** The `AudioNode` that handles audio in the plugin where the host can connect to/from */
-    audioNode: Node;
-    /** This will return true after calling `initialize()`. */
-    initialized: boolean;
-    /** The identifier of the current WAM, composed of vender + name */
-    readonly moduleId: string;
-    /** The unique identifier of the current WAM instance. */
-    readonly instanceId: string;
-    /** The values from `descriptor.json` */
-    readonly descriptor: WamDescriptor;
-    /** The WAM's name */
-    readonly name: string;
-    /** The WAM Vendor's name */
-    readonly vendor: string;
+import {V2_0_0} from "./versions/v2.0.0-alpha2"
 
-    /**
-     * This async method must be redefined to get `AudioNode` that
-     * will connected to the host.
-     * It can be any object that extends `AudioNode` and implements `WamNode`
-     */
-    createAudioNode(initialState?: any): Promise<WamNode>;
-    /**
-     * The host will call this method to initialize the WAM with an initial state.
-     *
-     * In this method, WAM devs should call `createAudioNode()`
-     * and store its return `AudioNode` to `this.audioNode`,
-     * then set `initialized` to `true` to ensure that
-     * the `audioNode` property is available after initialized.
-     *
-     * These two behaviors are implemented by default in the SDK.
-     *
-     * The WAM devs can also fetch and preload the GUI Element in while initializing.
-     */
-    initialize(state?: any): Promise<WebAudioModule>;
-    /** Redefine this method to get the WAM's GUI as an HTML `Element`. */
-    createGui(): Promise<Element>;
-    /** Clean up an element previously returned by `createGui` */
-    destroyGui(gui: Element): void
-}
+export interface WebAudioModule<Node extends WamNode = WamNode> extends V2_0_0.WebAudioModule {}
+export interface WamDescriptor extends V2_0_0.WamDescriptor {}
+export interface WamNodeOptions extends V2_0_0.WamNodeOptions{}
+export interface WamNode extends V2_0_0.WamNode{}
+export interface WamProcessor extends V2_0_0.WamProcessor{}
+export interface WamParameterConfiguration extends V2_0_0.WamParameterConfiguration{}
+export interface WamParameterInfo extends V2_0_0.WamParameterInfo{}
+export interface WamParameter extends V2_0_0.WamParameter{}
+export interface WamParameterData extends V2_0_0.WamParameterData{}
+export interface WamEventBase<T extends WamEventType = WamEventType, D = any> extends V2_0_0.WamEventBase {}
+export interface WamTransportData extends V2_0_0.WamTransportData{}
+
+export interface WamMidiData extends V2_0_0.WamMidiData {}
+export interface WamBinaryData extends V2_0_0.WamBinaryData{}
+export interface WamInfoData extends V2_0_0.WamInfoData{}
+export interface WamEventMap extends V2_0_0.WamEventMap{}
+export interface AudioParamDescriptor extends V2_0_0.AudioParamDescriptor{}
+export interface AudioWorkletProcessor extends V2_0_0.AudioWorkletProcessor{}
+export interface WamEnv extends V2_0_0.WamEnv{}
+export interface AudioWorkletGlobalScope extends V2_0_0.AudioWorkletGlobalScope{}
+
+export type WamIODescriptor = V2_0_0.WamIODescriptor
+export type WamParameterType = V2_0_0.WamParameterType
+export type WamParameterMap = V2_0_0.WamParameterMap
+export type WamParameterInfoMap = V2_0_0.WamParameterInfoMap
+export type WamParameterDataMap = V2_0_0.WamParameterDataMap
+export type WamEventType = V2_0_0.WamEventType
+
+export type WamEventCallback<E extends WamEventType = WamEventType> = V2_0_0.WamEventCallback<E>
+export type WamEvent = V2_0_0.WamEvent
+export type WamAutomationEvent = V2_0_0.WamAutomationEvent
+export type WamTransportEvent = V2_0_0.WamTransportEvent
+export type WamMidiEvent = V2_0_0.WamMidiEvent
+export type WamSysexEvent = V2_0_0.WamSysexEvent
+export type WamMpeEvent = V2_0_0.WamMpeEvent
+export type WamOscEvent = V2_0_0.WamOscEvent
+export type WamInfoEvent = V2_0_0.WamInfoEvent
+
+
 export const WebAudioModule: {
     prototype: WebAudioModule;
     /** should return `true` */
@@ -58,253 +49,33 @@ export const WebAudioModule: {
     new <Node extends WamNode = WamNode>(audioContext: BaseAudioContext): WebAudioModule<Node>;
 };
 
-export type WamIODescriptor = Record<`has${'Audio' | 'Midi' | 'Sysex' | 'Osc' | 'Mpe' | 'Automation'}${'Input' | 'Output'}`, boolean>;
-
-export interface WamDescriptor extends WamIODescriptor {
-    name: string;
-    vendor: string;
-    version: string;
-    apiVersion: string;
-    thumbnail: string;
-    keywords: string[];
-    isInstrument: boolean;
-    description: string;
-    website: string;
-}
-
-// Node
-
-export interface WamNodeOptions {
-    /** The identifier of the WAM `AudioWorkletProcessor`. */
-    processorId: string;
-    /** The unique identifier of the current WAM instance. */
-    instanceId: string;
-}
-export interface WamNode extends AudioNode, Readonly<WamNodeOptions> {
-    /** Current `WebAudioModule`. */
-    readonly module: WebAudioModule;
-
-    /** Get parameter info for the specified parameter ids, or omit argument to get info for all parameters. */
-    getParameterInfo(...parameterIdQuery: string[]): Promise<WamParameterInfoMap>;
-    /** Get parameter values for the specified parameter ids, or omit argument to get values for all parameters. */
-    getParameterValues(normalized?: boolean, ...parameterIdQuery: string[]): Promise<WamParameterDataMap>;
-    /** Set parameter values for the specified parameter ids. */
-    setParameterValues(parameterValues: WamParameterDataMap): Promise<void>;
-    /** Returns an object (such as JSON or a serialized blob) that can be used to restore the WAM's state. */
-    getState(): Promise<any>;
-    /** Use an object (such as JSON or a serialized blob) to restore the WAM's state. */
-    setState(state: any): Promise<void>;
-    /** Compensation delay hint in samples */
-    getCompensationDelay(): Promise<number>;
-    /** Register a callback function so it will be called when matching events are processed. */
-    addEventListener<K extends keyof WamEventMap>(type: K, listener: (this: this, ev: CustomEvent<WamEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
-    addEventListener(type: string, listener: (this: this, ev: CustomEvent) => any, options?: boolean | AddEventListenerOptions): void;
-    addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
-    /** Deregister a callback function so it will no longer be called when matching events are processed. */
-    removeEventListener<K extends keyof WamEventMap>(type: K, listener: (this: this, ev: CustomEvent<WamEventMap[K]>) => any, options?: boolean | EventListenerOptions): void;
-    removeEventListener(type: string, listener: (this: this, ev: CustomEvent) => any, options?: boolean | AddEventListenerOptions): void;
-    removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
-    /** Schedule a WamEvent. Listeners will be triggered when the event is processed. */
-    scheduleEvents(...event: WamEvent[]): void;
-    /** Clear all pending WamEvents. */
-    clearEvents(): void;
-    /** Connect an event output stream to another WAM. If no output index is given, assume output 0. */
-    connectEvents(to: WamNode, output?: number): void;
-    /** Disconnect an event output stream from another WAM. If no arguments are given, all event streams will be disconnected. */
-    disconnectEvents(to?: WamNode, output?: number): void;
-    /** Stop processing and remove the node from the graph. */
-    destroy(): void;
-}
 export const WamNode: {
     prototype: WamNode;
     new (module: WebAudioModule, options?: AudioWorkletNodeOptions): WamNode;
 };
-export interface WamProcessor extends AudioWorkletProcessor {
-    readonly moduleId: string;
-    readonly instanceId: string;
-    /** Compensation delay hint in seconds. */
-    getCompensationDelay(): number;
-    /** Schedule a WamEvent. Listeners will be triggered when the event is processed. */
-    scheduleEvents(...event: WamEvent[]): void;
-    /** Schedule events for all the downstream WAMs */
-    emitEvents(...events: WamEvent[]): void;
-    /** Clear all pending WamEvents. */
-    clearEvents(): void;
-    /** Process a block of samples. Note that `parameters` argument is ignored. */
-    process(inputs: Float32Array[][], outputs: Float32Array[][], parameters: Record<string, Float32Array>): boolean;
-    /** Stop processing and remove the node from the WAM event graph. */
-    destroy(): void;
-}
+    
 export const WamProcessor: {
     prototype: WamProcessor;
     new (options: AudioWorkletNodeOptions): WamProcessor;
 } & Pick<typeof AudioWorkletProcessor, "parameterDescriptors">;
 
-// PARAMETERS
-
-export type WamParameterType = 'float' | 'int' | 'boolean' | 'choice';
-
-export interface WamParameterConfiguration {
-    /** The parameter's human-readable name. */
-    label?: string;
-    /** The parameter's data type. */
-    type?: WamParameterType;
-    /** The parameter's default value. Must be within range `[minValue, maxValue]`. */
-    defaultValue?: number;
-    /** The minimum valid value of the parameter's range. */
-    minValue?: number;
-    /** The maximum valid value of the parameter's range. */
-    maxValue?: number;
-    /** The distance between adjacent valid integer values, if applicable. */
-    discreteStep?: number;
-    /** The nonlinear (exponential) skew of the parameter's range, if applicable. */
-    exponent?: number;
-    /** A list of human-readable choices corresponding to each valid value in the parameter's range, if applicable. */
-    choices?: string[];
-    /** A human-readable string representing the units of the parameter's range, if applicable. */
-    units?: string;
-}
-
-export interface WamParameterInfo extends Readonly<Required<WamParameterConfiguration>> {
-    /** The parameter's unique identifier. */
-    readonly id: string;
-    /** Convert a value from the parameter's denormalized range `[minValue, maxValue]` to normalized range `[0, 1]`. */
-    normalize(value: number): number;
-    /** Convert a value from normalized range `[0, 1]` to the parameter's denormalized range `[minValue, maxValue]`. */
-    denormalize(valueNorm: number): number;
-    /** Get a human-readable string representing the given value, including units if applicable. */
-    valueString(value: number): string;
-}
 export const WamParameterInfo: {
     prototype: WamParameterInfo;
     new (id: string, config?: WamParameterConfiguration): WamParameterInfo;
 };
-
-export interface WamParameter {
-    readonly info: WamParameterInfo;
-    value: number;
-    normalizedValue: number;
-}
+    
 export const WamParameter: {
     prototype: WamParameter;
     new (info: WamParameterInfo): WamParameter;
 };
 
-export interface WamParameterData {
-    id: string;
-    value: number;
-    normalized: boolean;
-}
-
-export type WamParameterMap = Record<string, WamParameter>;
-
-export type WamParameterInfoMap = Record<string, WamParameterInfo>;
-
-export type WamParameterDataMap = Record<string, WamParameterData>;
-
-// EVENTS
-
-export type WamEventType = keyof WamEventMap;
-
-export interface WamEventBase<T extends WamEventType = WamEventType, D = any> {
-    type: T;
-    data: D;
-    time?: number;
-}
-
-export interface WamTransportData {
-    /** Bar number */
-    currentBar: number;
-    /** Timestamp in seconds (WebAudio clock) */
-    currentBarStarted: number;
-    /** Beats per Minute */
-    tempo: number;
-    /** Beats count per Bar */
-    timeSigNumerator: number;
-    /** Beat duration indicator */
-    timeSigDenominator: number;
-    /** Determines if transport is active */
-    playing: boolean;
-}
-
-export interface WamMidiData {
-    bytes: [number, number, number];
-}
-
-export interface WamBinaryData {
-    bytes: Uint8Array;
-}
-
-export interface WamInfoData {
-    instanceId: string;
-}
-
-export type WamEventCallback<E extends WamEventType = WamEventType> = (event: WamEventMap[E]) => any;
-
-export interface WamEventMap {
-    'wam-automation': WamAutomationEvent;
-    'wam-transport': WamTransportEvent;
-    'wam-midi': WamMidiEvent;
-    'wam-sysex': WamSysexEvent;
-    'wam-mpe': WamMpeEvent;
-    'wam-osc': WamOscEvent;
-    'wam-info': WamInfoEvent;
-}
-
-export type WamEvent = WamAutomationEvent | WamTransportEvent | WamMidiEvent | WamSysexEvent | WamMpeEvent | WamOscEvent | WamInfoEvent;
-export type WamAutomationEvent = WamEventBase<'wam-automation', WamParameterData>;
-export type WamTransportEvent = WamEventBase<'wam-transport', WamTransportData>;
-export type WamMidiEvent = WamEventBase<'wam-midi', WamMidiData>;
-export type WamSysexEvent = WamEventBase<'wam-sysex', WamBinaryData>;
-export type WamMpeEvent = WamEventBase<'wam-mpe', WamMidiData>;
-export type WamOscEvent = WamEventBase<'wam-osc', WamBinaryData>;
-export type WamInfoEvent = WamEventBase<'wam-info', WamInfoData>;
-
-export interface AudioParamDescriptor {
-    automationRate?: AutomationRate;
-    defaultValue?: number;
-    maxValue?: number;
-    minValue?: number;
-    name: string;
-}
-export interface AudioWorkletProcessor {
-    port: MessagePort;
-    process(inputs: Float32Array[][], outputs: Float32Array[][], parameters: Record<string, Float32Array>): boolean;
-}
 export const AudioWorkletProcessor: {
     prototype: AudioWorkletProcessor;
     parameterDescriptors: AudioParamDescriptor[];
     new (options: AudioWorkletNodeOptions): AudioWorkletProcessor;
 };
-
-export interface WamEnv {
-    /** The version of the API used */
-    readonly apiVersion: string;
-    /** Stores a graph of WamProcessors connected with `connectEvents` for each output of processors */
-    readonly eventGraph: Map<WamProcessor, Set<WamProcessor>[]>;
-    /** processors map with `instanceId` */
-    readonly processors: Record<string, WamProcessor>;
-    /** The method should be called when a processor instance is created */
-    create(wam: WamProcessor): void;
-    /** Connect events between `WamProcessor`s, the output number is 0 by default */
-    connectEvents(from: WamProcessor, to: WamProcessor, output?: number): void;
-    /** Disonnect events between `WamProcessor`s, the output number is 0 by default, if `to` is omitted, will disconnect every connections */
-    disconnectEvents(from: WamProcessor, to?: WamProcessor, output?: number): void;
-    /** The method should be called when a processor instance is destroyed */
-    destroy(wam: WamProcessor): void;
-}
+    
 export const WamEnv: {
     prototype: WamEnv;
     new (): WamEnv;
-}
-
-export interface AudioWorkletGlobalScope {
-    AudioWorkletGlobalScope: any;
-    globalThis: AudioWorkletGlobalScope;
-    registerProcessor: (name: string, constructor: new (options: any) => AudioWorkletProcessor) => void;
-    currentFrame: number;
-    currentTime: number;
-    sampleRate: number;
-    AudioWorkletProcessor: typeof AudioWorkletProcessor;
-    webAudioModules: WamEnv;
 }

--- a/src/versions/v2.0.0-alpha2.d.ts
+++ b/src/versions/v2.0.0-alpha2.d.ts
@@ -1,0 +1,306 @@
+export module V2_0_0 {
+
+/**
+ * Main `WebAudioModule` interface,
+ * its constructor should be the `export default` of the ESM of each WAM.
+ *
+ * @template Node type of the `audioNode` property, could be any `AudioNode` that implements `WamNode`
+ */
+export interface WebAudioModule<Node extends WamNode = WamNode> {
+    /** should return `true` */
+    readonly isWebAudioModule: boolean;
+    /** The `AudioContext` where the plugin's node lives in */
+    audioContext: BaseAudioContext;
+    /** The `AudioNode` that handles audio in the plugin where the host can connect to/from */
+    audioNode: Node;
+    /** This will return true after calling `initialize()`. */
+    initialized: boolean;
+    /** The identifier of the current WAM, composed of vender + name */
+    readonly moduleId: string;
+    /** The unique identifier of the current WAM instance. */
+    readonly instanceId: string;
+    /** The values from `descriptor.json` */
+    readonly descriptor: WamDescriptor;
+    /** The WAM's name */
+    readonly name: string;
+    /** The WAM Vendor's name */
+    readonly vendor: string;
+
+    /**
+     * This async method must be redefined to get `AudioNode` that
+     * will connected to the host.
+     * It can be any object that extends `AudioNode` and implements `WamNode`
+     */
+    createAudioNode(initialState?: any): Promise<WamNode>;
+    /**
+     * The host will call this method to initialize the WAM with an initial state.
+     *
+     * In this method, WAM devs should call `createAudioNode()`
+     * and store its return `AudioNode` to `this.audioNode`,
+     * then set `initialized` to `true` to ensure that
+     * the `audioNode` property is available after initialized.
+     *
+     * These two behaviors are implemented by default in the SDK.
+     *
+     * The WAM devs can also fetch and preload the GUI Element in while initializing.
+     */
+    initialize(state?: any): Promise<WebAudioModule>;
+    /** Redefine this method to get the WAM's GUI as an HTML `Element`. */
+    createGui(): Promise<Element>;
+    /** Clean up an element previously returned by `createGui` */
+    destroyGui(gui: Element): void
+}
+
+export type WamIODescriptor = Record<`has${'Audio' | 'Midi' | 'Sysex' | 'Osc' | 'Mpe' | 'Automation'}${'Input' | 'Output'}`, boolean>;
+
+export interface WamDescriptor extends WamIODescriptor {
+    name: string;
+    vendor: string;
+    version: string;
+    apiVersion: string;
+    thumbnail: string;
+    keywords: string[];
+    isInstrument: boolean;
+    description: string;
+    website: string;
+}
+
+// Node
+
+export interface WamNodeOptions {
+    /** The identifier of the WAM `AudioWorkletProcessor`. */
+    processorId: string;
+    /** The unique identifier of the current WAM instance. */
+    instanceId: string;
+}
+export interface WamNode extends AudioNode, Readonly<WamNodeOptions> {
+    /** Current `WebAudioModule`. */
+    readonly module: WebAudioModule;
+
+    /** Get parameter info for the specified parameter ids, or omit argument to get info for all parameters. */
+    getParameterInfo(...parameterIdQuery: string[]): Promise<WamParameterInfoMap>;
+    /** Get parameter values for the specified parameter ids, or omit argument to get values for all parameters. */
+    getParameterValues(normalized?: boolean, ...parameterIdQuery: string[]): Promise<WamParameterDataMap>;
+    /** Set parameter values for the specified parameter ids. */
+    setParameterValues(parameterValues: WamParameterDataMap): Promise<void>;
+    /** Returns an object (such as JSON or a serialized blob) that can be used to restore the WAM's state. */
+    getState(): Promise<any>;
+    /** Use an object (such as JSON or a serialized blob) to restore the WAM's state. */
+    setState(state: any): Promise<void>;
+    /** Compensation delay hint in samples */
+    getCompensationDelay(): Promise<number>;
+    /** Register a callback function so it will be called when matching events are processed. */
+    addEventListener<K extends keyof WamEventMap>(type: K, listener: (this: this, ev: CustomEvent<WamEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
+    addEventListener(type: string, listener: (this: this, ev: CustomEvent) => any, options?: boolean | AddEventListenerOptions): void;
+    addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
+    /** Deregister a callback function so it will no longer be called when matching events are processed. */
+    removeEventListener<K extends keyof WamEventMap>(type: K, listener: (this: this, ev: CustomEvent<WamEventMap[K]>) => any, options?: boolean | EventListenerOptions): void;
+    removeEventListener(type: string, listener: (this: this, ev: CustomEvent) => any, options?: boolean | AddEventListenerOptions): void;
+    removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
+    /** Schedule a WamEvent. Listeners will be triggered when the event is processed. */
+    scheduleEvents(...event: WamEvent[]): void;
+    /** Clear all pending WamEvents. */
+    clearEvents(): void;
+    /** Connect an event output stream to another WAM. If no output index is given, assume output 0. */
+    connectEvents(to: WamNode, output?: number): void;
+    /** Disconnect an event output stream from another WAM. If no arguments are given, all event streams will be disconnected. */
+    disconnectEvents(to?: WamNode, output?: number): void;
+    /** Stop processing and remove the node from the graph. */
+    destroy(): void;
+}
+export const WamNode: {
+    prototype: WamNode;
+    new (module: WebAudioModule, options?: AudioWorkletNodeOptions): WamNode;
+};
+export interface WamProcessor extends AudioWorkletProcessor {
+    readonly moduleId: string;
+    readonly instanceId: string;
+    /** Compensation delay hint in seconds. */
+    getCompensationDelay(): number;
+    /** Schedule a WamEvent. Listeners will be triggered when the event is processed. */
+    scheduleEvents(...event: WamEvent[]): void;
+    /** Schedule events for all the downstream WAMs */
+    emitEvents(...events: WamEvent[]): void;
+    /** Clear all pending WamEvents. */
+    clearEvents(): void;
+    /** Process a block of samples. Note that `parameters` argument is ignored. */
+    process(inputs: Float32Array[][], outputs: Float32Array[][], parameters: Record<string, Float32Array>): boolean;
+    /** Stop processing and remove the node from the WAM event graph. */
+    destroy(): void;
+}
+export const WamProcessor: {
+    prototype: WamProcessor;
+    new (options: AudioWorkletNodeOptions): WamProcessor;
+} & Pick<typeof AudioWorkletProcessor, "parameterDescriptors">;
+
+// PARAMETERS
+
+export type WamParameterType = 'float' | 'int' | 'boolean' | 'choice';
+
+export interface WamParameterConfiguration {
+    /** The parameter's human-readable name. */
+    label?: string;
+    /** The parameter's data type. */
+    type?: WamParameterType;
+    /** The parameter's default value. Must be within range `[minValue, maxValue]`. */
+    defaultValue?: number;
+    /** The minimum valid value of the parameter's range. */
+    minValue?: number;
+    /** The maximum valid value of the parameter's range. */
+    maxValue?: number;
+    /** The distance between adjacent valid integer values, if applicable. */
+    discreteStep?: number;
+    /** The nonlinear (exponential) skew of the parameter's range, if applicable. */
+    exponent?: number;
+    /** A list of human-readable choices corresponding to each valid value in the parameter's range, if applicable. */
+    choices?: string[];
+    /** A human-readable string representing the units of the parameter's range, if applicable. */
+    units?: string;
+}
+
+export interface WamParameterInfo extends Readonly<Required<WamParameterConfiguration>> {
+    /** The parameter's unique identifier. */
+    readonly id: string;
+    /** Convert a value from the parameter's denormalized range `[minValue, maxValue]` to normalized range `[0, 1]`. */
+    normalize(value: number): number;
+    /** Convert a value from normalized range `[0, 1]` to the parameter's denormalized range `[minValue, maxValue]`. */
+    denormalize(valueNorm: number): number;
+    /** Get a human-readable string representing the given value, including units if applicable. */
+    valueString(value: number): string;
+}
+export const WamParameterInfo: {
+    prototype: WamParameterInfo;
+    new (id: string, config?: WamParameterConfiguration): WamParameterInfo;
+};
+
+export interface WamParameter {
+    readonly info: WamParameterInfo;
+    value: number;
+    normalizedValue: number;
+}
+export const WamParameter: {
+    prototype: WamParameter;
+    new (info: WamParameterInfo): WamParameter;
+};
+
+export interface WamParameterData {
+    id: string;
+    value: number;
+    normalized: boolean;
+}
+
+export type WamParameterMap = Record<string, WamParameter>;
+
+export type WamParameterInfoMap = Record<string, WamParameterInfo>;
+
+export type WamParameterDataMap = Record<string, WamParameterData>;
+
+// EVENTS
+
+export type WamEventType = keyof WamEventMap;
+
+export interface WamEventBase<T extends WamEventType = WamEventType, D = any> {
+    type: T;
+    data: D;
+    time?: number;
+}
+
+export interface WamTransportData {
+    /** Bar number */
+    currentBar: number;
+    /** Timestamp in seconds (WebAudio clock) */
+    currentBarStarted: number;
+    /** Beats per Minute */
+    tempo: number;
+    /** Beats count per Bar */
+    timeSigNumerator: number;
+    /** Beat duration indicator */
+    timeSigDenominator: number;
+    /** Determines if transport is active */
+    playing: boolean;
+}
+
+export interface WamMidiData {
+    bytes: [number, number, number];
+}
+
+export interface WamBinaryData {
+    bytes: Uint8Array;
+}
+
+export interface WamInfoData {
+    instanceId: string;
+}
+
+export type WamEventCallback<E extends WamEventType = WamEventType> = (event: WamEventMap[E]) => any;
+
+export interface WamEventMap {
+    'wam-automation': WamAutomationEvent;
+    'wam-transport': WamTransportEvent;
+    'wam-midi': WamMidiEvent;
+    'wam-sysex': WamSysexEvent;
+    'wam-mpe': WamMpeEvent;
+    'wam-osc': WamOscEvent;
+    'wam-info': WamInfoEvent;
+}
+
+export type WamEvent = WamAutomationEvent | WamTransportEvent | WamMidiEvent | WamSysexEvent | WamMpeEvent | WamOscEvent | WamInfoEvent;
+export type WamAutomationEvent = WamEventBase<'wam-automation', WamParameterData>;
+export type WamTransportEvent = WamEventBase<'wam-transport', WamTransportData>;
+export type WamMidiEvent = WamEventBase<'wam-midi', WamMidiData>;
+export type WamSysexEvent = WamEventBase<'wam-sysex', WamBinaryData>;
+export type WamMpeEvent = WamEventBase<'wam-mpe', WamMidiData>;
+export type WamOscEvent = WamEventBase<'wam-osc', WamBinaryData>;
+export type WamInfoEvent = WamEventBase<'wam-info', WamInfoData>;
+
+export interface AudioParamDescriptor {
+    automationRate?: AutomationRate;
+    defaultValue?: number;
+    maxValue?: number;
+    minValue?: number;
+    name: string;
+}
+export interface AudioWorkletProcessor {
+    port: MessagePort;
+    process(inputs: Float32Array[][], outputs: Float32Array[][], parameters: Record<string, Float32Array>): boolean;
+}
+export const AudioWorkletProcessor: {
+    prototype: AudioWorkletProcessor;
+    parameterDescriptors: AudioParamDescriptor[];
+    new (options: AudioWorkletNodeOptions): AudioWorkletProcessor;
+};
+
+export interface WamEnv {
+    /** The version of the API used */
+    readonly apiVersion: string;
+    /** Stores a graph of WamProcessors connected with `connectEvents` for each output of processors */
+    //readonly eventGraph: Map<WamProcessor, Set<WamProcessor>[]>;
+    /** processors map with `instanceId` */
+    //readonly processors: Record<string, WamProcessor>;
+    
+    /** The method should be called when a processor instance is created */
+    create(wam: WamProcessor): void;
+    /** Connect events between `WamProcessor`s, the output number is 0 by default */
+    connectEvents(from: WamProcessor, to: WamProcessor, output?: number): void;
+    /** Disonnect events between `WamProcessor`s, the output number is 0 by default, if `to` is omitted, will disconnect every connections */
+    disconnectEvents(from: WamProcessor, to?: WamProcessor, output?: number): void;
+    /** The method should be called when a processor instance is destroyed */
+    destroy(wam: WamProcessor): void;
+}
+export const WamEnv: {
+    prototype: WamEnv;
+    new (): WamEnv;
+}
+
+export interface AudioWorkletGlobalScope {
+    AudioWorkletGlobalScope: any;
+    globalThis: AudioWorkletGlobalScope;
+    registerProcessor: (name: string, constructor: new (options: any) => AudioWorkletProcessor) => void;
+    currentFrame: number;
+    currentTime: number;
+    sampleRate: number;
+    AudioWorkletProcessor: typeof AudioWorkletProcessor;
+    webAudioModules: WamEnv;
+}
+
+}


### PR DESCRIPTION
🔴 FOR DISCUSSION 🔴 

I'm exploring an approach for the WAM2 API/SDK to support WAMs built with older versions of the API/SDK.

The general idea is that, when an older WAM is loaded, WamEnv will need to wrap the older WAM with a shim object that implements backwards compatibility, so that the rest of the system can treat the old WAM as if it were built with the current SDK version.

One requirement to do this easily will be to know the typescript definitions for older WAM SDKs.  So the idea here is, each API version defines its types inside a `Vx.y.z` namespace, and then the API exposes the "current" versions.

I'm interested in your thoughts, alternative approaches, whether you agree this is a problem we need to solve, ...

Some things I'm uncertain about:
- can we move the `export const` definitions out of `types.d.ts` and into the versioned namespace.
- should versions be wrapped in a module, or a namespace?

Next steps, other problems that would need to be solved as well:
- On load WAMs made with an older SDK version should be wrapped with an interop layer to upgrade them to the newer SDK version
- Similarly, the WamEnv that is exposed to a WAM built with an older SDK would have to implement the older WamEnv API.  This will likely require refactoring the WamEnv interface that a WAM sees, so that we can easily shim this layer to what the older WAM would expect.  For example WAMs should not be able to get direct references from one to another, or else we'd need to have shims all OVER the place 😬 
- 